### PR TITLE
LocalStorage-based Persistent State

### DIFF
--- a/src/components/App/Controls/index.js
+++ b/src/components/App/Controls/index.js
@@ -15,6 +15,7 @@ export default Component.register(import.meta.url, ({className, id}) =>
                    {id: 'uniforms', label: 'Uniforms', content: <Uniforms/>}]}/>
     </div>
     <div className={className+'-State'}>
+      &nbsp;<button type="button" className={className+'-Button clear-state'}>Clear State</button>
       <div className={className+'-StateHeadline'}>Download State:</div>
       &nbsp;<button type="button" className={className+'-Button save-json'}>.json</button>
       &nbsp;<button type="button" className={className+'-Button save-zip'}>.zip</button>

--- a/src/components/App/Controls/instance.js
+++ b/src/components/App/Controls/instance.js
@@ -19,6 +19,10 @@ Controls.prototype = {
     downloadEl.style.display = 'none'
     this.el.appendChild(downloadEl)
 
+    this.el.querySelector(`.${escapeCSS(this.className)}-Button.clear-state`).addEventListener('click', e => {
+      this.app.state = this.app.defaultState
+    })
+
     this.el.querySelector(`.${escapeCSS(this.className)}-Button.save-json`).addEventListener('click', e => {
       const file = new Blob([JSON.stringify(this.app.state)], {type: 'text/json'})
       downloadEl.download = 'shaderlab.json'

--- a/src/components/App/instance.js
+++ b/src/components/App/instance.js
@@ -12,7 +12,8 @@ function App(el, {className, props}) {
 App.prototype = {
   initialize() {
     this.stateEl = this.el.querySelector(`.${escapeCSS(this.className)}-State`)
-    this.state = JSON.parse(this.stateEl.value)
+    this.state = JSON.parse(localStorage.getItem('state') || this.stateEl.value)
+    this.defaultState = JSON.parse(this.stateEl.value)
     this.stateChangeThrottle && clearTimeout(this.stateChangeThrottle)
 
     // Watch canvas panel size and update the canvas' viewport
@@ -124,11 +125,16 @@ App.prototype = {
     this.canvas.state = state.output
   },
 
+  onStateChanged() {
+    localStorage.setItem('state', JSON.stringify(this.state))
+  },
+
   announceStateChange() {
     this.stateChangeThrottle && clearTimeout(this.stateChangeThrottle)
     this.stateChangeThrottle = setTimeout(() => {
       this.stateChangeThrottle = undefined
       this.stateEl.value = JSON.stringify(this.state)
+      this.onStateChanged()
       this.el.dispatchEvent(new Event('stateChanged'))
     }, 500)
   }


### PR DESCRIPTION
1st part of #12.

The application state is committed to LocalStorage and retrieved whenever the application loads. If there is no stored value, uses default state.

Clearing browser cache will erase the stored state!

Additionally, adds a UI button to reset application state to defaults.