### PR TITLE
Reduce KSU Calls on Deploy

### DIFF
--- a/server/update.sh
+++ b/server/update.sh
@@ -21,8 +21,6 @@ else
     COMMAND_SUFFIX="\""
 fi
 
-ssh $USR@$SRV "$COMMAND_PREFIX usermod -a -G deployment $USR$COMMAND_SUFFIX"
-
 git push --force ssh://$USR@$SRV:$GITDIR HEAD:master
 APP_UPDATE_SCRIPT="$(basename `git rev-parse --show-toplevel`)-$(git rev-parse HEAD)-app-update.sh"
 rsync -v --info=progress2 $DIR/app/update.sh $USR@$SRV:/tmp/$APP_UPDATE_SCRIPT


### PR DESCRIPTION
Multiple remote `ksu` commands were being called by the previous scripts, this increases the risk of a password leaking due to the visibility of the `ksu` password. Now only 2 `ksu` commands are required to fully init and deploy the system.